### PR TITLE
numerous minor guideline format changes

### DIFF
--- a/library/guidelines.md
+++ b/library/guidelines.md
@@ -13,7 +13,7 @@
 - Donald Trump is coming to the UK on June 25th according to this New York Times story
 - Man yelled 'Britain first!'
 
-## counter examples ##
+## counterexamples ##
 - most of them are not refugees
   + missing entity
 - URLs: Cameron confirmed on Monday that [URL]
@@ -29,7 +29,7 @@
 - frequently reasoning about consequences of past events or future results of things
 - speculations
 - premise sufficient
-- often in combination with p5
+- often in combination with #5
 - basically any implication where there is a reason (not necessarily given) why truth of the antecedent is causing and not just correlating with truth of the consequent
 
 ## examples ##
@@ -37,7 +37,7 @@
 - Zach's relentless negative campaigning brought out the London vote
 - Brits will never control our country again if we vote IN
 
-## counter examples ##
+## counterexamples ##
 - if ever you needed confirmation for Brexit, these three provide it
   + no causal relationship
   
@@ -45,12 +45,12 @@
 - #23 + causal relationship
 
 # 3 Desire #
-- **entity** wants **formula**
-- **formula** cannot be just an **entity**:
-  + "**entity** backs **cameron**" != "**entity** desires **cameron**"
-- the **entity** should be explicitly marked
+- **ENTITY** wants **FORMULA**
+- **FORMULA** cannot be just an **ENTITY**:
+  + "**ENTITY** backs **cameron**" != "**ENTITY** desires **cameron**"
+- the entity should be explicitly marked
 - an exception applies for ellipsis (i.e. when the subject is not realised in the surface form)
-  + here, the **entity** is the author of the message
+  + here, the entity is the author of the message
 
 ## cues ##
 - verbs of desire (*want*, *wish*) of a particular outcome or event
@@ -64,7 +64,7 @@
 - **We** are really looking forward to **this**
 - **they** endorse **Brexit**
 
-## counter examples ##
+## counterexamples ##
 - silent majority for brexit
   + entity is undefined subset
 - the pro brexit campaigners are using this strategy
@@ -72,12 +72,12 @@
 - a person supporting brexit / many people supporting brexit say ... 
   + not specified who the entities are
 - he is *against* it
-  + pattern #55
+  + #55
 - SF have issues with EU but *see it as better* for NI to remain
   + one-sided preference without explicit marking of desire
   + here: because they might not actually want to remain, despite seeing this as the rationally best decision
 - democracy should be protected
-  + pattern #4
+  + #4
   + the 'wanter' is implicit in a non-elliptical sentence
 - he *voted* remain 
   + might be interpreted as him wanting *remain* to be made true, but we do not consider such actions a sufficiently clear expression of desire
@@ -112,7 +112,7 @@
 - it is important to brexit
 - entity should win the medal
 
-## counter examples ##
+## counterexamples ##
 - entity should practice harder
 
 ## confusions ##
@@ -141,44 +141,51 @@
 - **Brexit** may seem like the **West's** **biggest problem**
 - **Brexit** is **bad** for **us**
 
-## counter examples ##
-- Johnson is a bad person (pattern 21)
-- if we Brexit, the rest of the world will view us as racist, bigoted and narrow- minded (too implicit -- while being viewed as racist etc. is a bad thing, the speaker has not stated that they care what people think)
-- @UKIP can take votes from Labour (too implicit -- taking votes is damaging according to world knowledge, but taking something away is not unambiguously bad)
-- its illegal immigrants that are entering through the EU on false documents or nothing at all that worries me.  (being worried is unpleasant, but not necessarily damaging)
+## counterexamples ##
+- Johnson is a bad person
+  + #21
+- if we Brexit, the rest of the world will view us as racist, bigoted and narrow- minded
+  + too implicit — while being viewed as racist etc. is a bad thing, the speaker has not stated that they care what people think
+- @UKIP can take votes from Labour 
+  + too implicit — taking votes is damaging according to world knowledge, but taking something away is not unambiguously bad
+- its illegal immigrants that are entering through the EU on false documents or nothing at all that worries me.
+  + being worried is unpleasant, but not necessarily damaging
 
 # 8 Good for Concept #
 - FORMULA is / would be good for CONCEPT
 - concept can be entity (e.g. person) or system (e.g. economy, environment)
 
 ## examples ##
-- the **UK** will be **better of** **out of the EU**
-- **Brexit** might have a **positive effect** on **the EU**
-- **Brexit** will only **improve** things for **the minority**
-- **I** am ... **enjoying** **following your comments on brexit**
+- the **UK** will be *better of* **out of the EU**
+- **Brexit** might have a *positive effect* on **the EU**
+- **Brexit** will only *improve* things for **the minority**
+- **I** am ... *enjoying* **following your comments on brexit**
 - **vote #remain** to keep **Greece** safe!
 
-## counter examples ##
+## counterexamples ##
 - Johnson is a good person
-- @Nissan is the biggest private sector employer in the North East - massive investor in Britain, job + car creator (too implicit -- investing / employing not inherently positive)
+- @Nissan is the biggest private sector employer in the North East - massive investor in Britain, job + car creator
+  + too implicit — investing / employing not inherently positive
 
 # 10 Belief #
 - ENTITY believes / thinks that FORMULA is true
 - ENTITY is sure that FORMULA is true
-- Can be difficult to separate from knowledge (pattern 34) based on cue words
+- Can be difficult to separate from knowledge (#34) based on cue words
 
 ## examples ##
-- I **don't think** people realise the severity of the consequences of voting to leave
+- I don't think people realise the severity of the consequences of voting to leave
 - I believe they will
 - i agree the sooner we leave the better
 - I believe in votes at 16 and no GRP for transgender people (= I believe this ought to be made true)
 - I think this could work
 
-## counter-examples ##
-- I agree with her about Brexit (there is reference to belief here, but it is unclear who believes what; we only learn that 'I' and 'her' believe different things w.r.t. Brexit)
-- I'm thinking of a solution (= thinking as a general cognitive process vs. thinking as belief)
+## counterexamples ##
+- I agree with her about Brexit
+  + there is reference to belief here, but it is unclear who believes what; we only learn that 'I' and 'her' believe different things w.r.t. Brexit
+- I'm thinking of a solution
+  + thinking as a general cognitive process vs. thinking as belief
 
-## confusions
+## confusions ##
 - #0
 - #34: I know it's bad
 
@@ -190,13 +197,13 @@
 - if we get out we can decide
 - why would we no longer be able to sell them
 
-## counter examples ##
+## counterexamples ##
 - the sheep can move to Islamabad and take their €€with them
   + hidden imperative
 - Remain can't see it
   + the may be able to see it, but they don't want to
 
-### confusions ##
+## confusions ##
 - #36
 
 # 12 Default Implication #
@@ -218,26 +225,29 @@
 - Boris Johnson, another Nigel Farage
 - #EUref feels similar to Scottish Referendum
 
-## counter examples ##
+## counterexamples ##
 - there is a link between Brexit and mental illness
   + correlation
 
 # 16 Expressed Preference #
 - ENTITY prefers FORMULA over FORMULA
-- like in pattern #3, the ENTITY can be left out by ellipsis
+- like in #3, the ENTITY can be left out by ellipsis
 
 ## examples ##
 - a lot fo tories would gladly trade Scotland for Brexit
 - it 's all coulds and not woulds , il take my chance with coulds and brexit
 - we go for quality rather than quantity
 
-## counter examples ##
+## counterexamples ##
 - "pure" evaluative comparisons that do not indicate an ENTITY's necessary desire for either formula (*direct democracy is better than representative democracy*), #42
 - one of the options is implicit (*I prefer brexit*), which is then #3
 - general preferability of a concept over another without ascribing the preference to any entity:
   + *It is better to leave than to remain*: user who posted the tweet prefers leaving over remaining
-- he was leave, but has *switched* to remain: not a hit because 1) preference can only be inferred  2) "was leave" is treated as group membership
-- it should be real ale, not some gassy lager: missing ENTITY; no explicit preference
+- he was leave, but has *switched* to remain
+  + preference can only be inferred
+  + "was leave" is treated as group membership
+- it should be real ale, not some gassy lager
+  + missing ENTITY; no explicit preference
 
 ## confusions ##
 - #3: see above
@@ -264,20 +274,20 @@
 - ENTITY lies about FORMULA
 - ENTITY says FORMULA but believes FORMULA is not true
 - an ENTITY is claimed to be lying (by the author of the text or someone referred to in the text) about a topic or the truth of a FORMULA; the lie can be about:
-  - a topic (*And believe* **this man** *who told lies* **about Iraq**)
-  - a particular claim (*For anyone who still believes the enduring* **Brexit** *lie* **that the EU is undemocratic**)
-  - a claim that is not elaborated upon in the given message, but clearly concerns a particular lie (*@JunckerEU says* **Boris** **making up stories**)
+  + a topic (*And believe* **this man** *who told lies* **about Iraq**)
+  + a particular claim (*For anyone who still believes the enduring* **Brexit** *lie* **that the EU is undemocratic**)
+  + a claim that is not elaborated upon in the given message, but clearly concerns a particular lie (*@JunckerEU says* **Boris** **making up stories**)
 
 ## examples ##
 - this lie that young people can't travel, it's another stay lie
 - David Cameron and George Osborne’s ‘ lies ’ over Brexit warnings
 - @BBCr4today running as its top story a Brexit lie
 
-## counter examples ##
+## counterexamples ##
 - the entity is accused of being generally dishonest, without specification of what they were lying about
 - the entity is accused of being unsincere in some other way, e.g. hypocritical, scaremongering...
-- the entity is accused of saying something that is untrue -- it has to be clear from the context that they are deliberately saying something incorrect 
-  + **X is talking BS** is a negative example
+- the entity is accused of saying something that is untrue — it has to be clear from the context that they are deliberately saying something incorrect 
+  + *X is talking BS* is a negative example
 
 ## confusions ##
 - #21: more bullshit from the in camp , next they'll be claiming that Brexit ' could ' cause Mars to crash in to Venus lol
@@ -294,7 +304,7 @@
 - Remain puppets
 - more bullshit from the in camp , next they'll be claiming that Brexit ' could ' cause Mars to crash in to Venus lol
 
-## counter examples ##
+## counterexamples ##
 - cunt.
   + only disqualifying accusations are ad hominem
 
@@ -311,51 +321,56 @@
 - #35
 
 # 23 Implication #
-- if FORMULA then FORMULA
+- if FORMULA, then FORMULA
 
 ## examples ##
 - if every you needed confirmation for brexit, these three provide it
 - if I was leaning towards BREXIT , their campaign being ran by Farage , Boris & The Sun will give me 2nd thoughts
 
-## counter examples ##
+## counterexamples ##
 - if every you needed a list what happens if we brexit, it's simple: prices will rise
 
 ## confusions ##
-- #2: here no causal implication (in dubio pattern 2)
+- #2: here no causal implication (in dubio #2)
 
 # 24 Membership #
 - ENTITY is part of ENTITY GROUP
-- For this pattern, entities have to have agency (e.g. people, organisations or states, but not abstract entities, objects or ideas)
-- Groups are defined widely, with prototypical cases including e.g. professions, parties/organisations or nationalities
-- Formal distinction at the blurry line between group and attribute: when in doubt, an adjective does not designate a group even if the corresponding noun does (she's a German: yes, she's German: no)
-- We also annotate ad-hoc groups (cf. first example)
-- Pattern 24 only covers statements about group memberships that go beyond purely characterising the entity. I.e. examples will often involve an entity and a verb phrase (e.g. is a member of) or a genitive construction (XY's membership in Z). Group statements that only specify the entity's background (e.g. via a modifying noun phrase) are annotated as pattern 57.
+- for this pattern, entities have to have agency (e.g. people, organisations or states, but not abstract entities, objects or ideas)
+- groups are defined widely, with prototypical cases including e.g. professions, parties/organisations or nationalities
+- formal distinction at the blurry line between group and attribute: when in doubt, an adjective does not designate a group even if the corresponding noun does (she's a German: yes, she's German: no)
+- we also annotate ad hoc groups (cf. first example)
 
 ## examples ##
 - **The clintons** are **fat cats** who are owned by the multinationals
 - **Jo** was **a politician**
 - three parties that want to be in the EU but not in the UK
+- **star economist** **Thomas Pickety**
 - **he's** **a leaver**
+- **billionaire brexit supporter** **Max Smith**
 - "**Stuart Rose** has switched sides to **#Leave"**
 - "**Brits** are too much **cowards** to vote" (24 + 25)
 - **we're** on the side of **leave**
+- **Scotland** should remain in **EU**
 - **we** are all **stupid people**
+- **the EU slave nations** **Germany and France**
 
-## counter examples ##
+## counterexamples ##
 - the president is British
-- he supports leave: pattern 3
+- he supports leave
+  + #3
 - "a billionaire brexit supporter"
-- **The UK** will leave **the EU**
-- we are all stupid (property rather than group definition)
-- Brexit will help other EU slave nations (group specification, but missing entity).
+- The UK will leave the EU
+- we are all stupid
+  + property rather than group definition
+- Brexit will help other EU slave nations
+  + group specification, but missing entity
 - It is an unfortunate coincidence that this happened
-- They will stay in the EU (*stay* technically implies an existing membership, but in this case is read as an action rather than membership)
-- I left the band (leaving = action resulting in membership rather than membership per se)
-- She joined the group (joining = action rather than membership)
-- the EU slave nations Germany and France (57)
-- star economist Thomas Pickety (57)
-- The Times' Jane Smith (57)
-
+- They will stay in the EU
+  + *stay* technically implies an existing membership, but in this case is read as an action rather than membership
+- I left the band
+  + leaving = action resulting in membership rather than membership per se
+- She joined the group
+  + joining = action rather than membership
 
 # 25 Universal Quantification [!] #
 - ENTITY is / does something
@@ -365,7 +380,7 @@
 - UKIP are a one trick pony
 - we all love and support each other
 
-## counter examples ##
+## counterexamples ##
 - I don't like this at all
 
 # 26 Position to Know #
@@ -374,7 +389,7 @@
 ## examples ##
 - we European knows it and see our culture disappearing
 
-## counter examples ##
+## counterexamples ##
 - as an immigrant , son of immigrants and having been subject to racsim I am firmly for Brexit
 
 # 27 Negation [!] #
@@ -385,7 +400,7 @@
 - most of them are NOT ' refugees ' at all
 
 # 30 Action Execution #
-- ENTITY have verb'ed
+- ENTITY has done ACTION
 
 ## examples ##
 - i've voted brexit
@@ -393,7 +408,7 @@
 - EU secured employment rights on a number of occasions
 - someone actually done that
 
-## counter examples ##
+## counterexamples ##
 - I've been in Africa since 1980
   + stative verbs
 
@@ -405,7 +420,7 @@
 
 # 34 Knowledge #
 - ENTITY knows FORMULA is true
-- Knowledge is considered from the entity's point of view; i.e. regardless of whether FORMULA is **actually** true 
+- Knowledge is considered from the entity's point of view; i.e. regardless of whether FORMULA is *actually* true 
 
 ## examples ##
 - I know that Nigel Farage didn't murder that MP
@@ -415,12 +430,14 @@
 - I'm certain it will break up or change dramatically
 - **The president** understands that **this is true**
 
-## counter-examples ##
-- You know, this was really a stupid idea ('you know' as a discourse marker)
-- Cameron should know about Brexit (know about a topic != know the  truth of a particular statement)
+## counterexamples ##
+- You know, this was really a stupid idea
+  + 'you know' as a discourse marker
+- Cameron should know about Brexit
+  + know about a topic != know the  truth of a particular statement
 
 ## confusions ##
-p10: belief
+- #10: belief
 
 # 35 Necessary Truth #
 - FORMULA will always be the case
@@ -449,8 +466,8 @@ p10: belief
 
 # 38 Warning #
 - ENTITY warns of FORMULA being generally bad (i.e. not just bad for any particular entity or group)
-- The warning can be encoded in the speech act (e.g. warning), or in the quoted speech itself (e.g. saying that something would be terrible)
-- This pattern differs from warnings of bad consequences (p 41/49 depending on whether consequences are bad for some or in general)
+- the warning can be encoded in the speech act (e.g. warning), or in the quoted speech itself (e.g. saying that something would be terrible)
+- this pattern differs from warnings of bad consequences (#41/49 depending on whether consequences are bad for some or in general)
 - expressions not relating directly to damage/danger but to changes in size/amount are not considered here, but understood as (negative) consequences
 
 ## examples ##
@@ -458,11 +475,15 @@ p10: belief
 - Cameron warns against Brexit in patriotic speech
 - Scientists including Stephen Hawking say a vote for Brexit in this month's EU referendum would be a disaster
 
-## counter examples ##
-- neither the verb nor formula 1 have an unambiguously negative evaluation (e.g. *the IMF said that brexit will prolong austerity*: austerity may be negative for many people, but not necessarily for everyone)
-- Hilary Benn has warned that Britain 's exit from the EU would make the country ' poorer ' and ' less influential' [49: bad consequences for some]
-- He predicted that Brexit would cause the pound to fall [41: bad consequence -- decrease in value vs. explicit damage]
-- She has threatened to vote out (threats are not considered general warnings)
+## counterexamples ##
+- the IMF said that brexit will prolong austerity
+  + neither the verb nor formula 1 have an unambiguously negative evaluation (e.g. austerity may be negative for many people, but not necessarily for everyone)
+- Hilary Benn has warned that Britain 's exit from the EU would make the country ' poorer ' and ' less influential'
+  + 49: bad consequences for some
+- He predicted that Brexit would cause the pound to fall 
+  + 41: bad consequence — decrease in value vs. explicit damage
+- She has threatened to vote out 
+  + threats are not considered general warnings
 
 # 39 Some [!] #
 
@@ -476,15 +497,16 @@ p10: belief
 
 # 41 Warning of Bad Consequence #
 - ENTITY says that FORMULA would lead to bad FORMULA
-- indirect version of p38 where something is claimed to be bad by consequence
+- indirect version of #38 where something is claimed to be bad by consequence
 - bad consequences include changes in size/amount etc. that are considered bad by general consensus
 
 ## examples ##
 - **Richard Haass**' claim that **Brexit** could 'trigger **NI violence**'
 - **Experts** warn that **brexit** could cause the **pound to fall**
 
-## counter examples ##
-- Brexit has brought out the bigots and racists [is matched by the logical formula = something has bad consequences, but is not a warning of bad consequences because warning's don't make sense for things that have already happened] 
+## counterexamples ##
+- Brexit has brought out the bigots and racists
+  + is matched by the logical formula = something has bad consequences, but is not a warning of bad consequences because warnings don't make sense for things that have already happened 
 
 # 42 Better #
 - FORMULA1 is universally (=for all) better than FORMULA2
@@ -493,40 +515,47 @@ p10: belief
 - Brexit is still better than being in the EU
 - We are better than this
 
-## counter examples ##
-- is there anything worse than a missed flight (pragmatically: #45)
-- it should be real ale, not some gassy lager: too implicit
-- your guess is as good as mine (idiom = 'I don't know')
-- Brexit -carefully managed by cool headed diplomats - cd be better but Remain can't see it (missing FORMULA2)
+## counterexamples ##
+- is there anything worse than a missed flight
+  + pragmatically: #45
+- it should be real ale, not some gassy lager
+  + too implicit
+- your guess is as good as mine
+  + idiom = 'I don't know'
+- Brexit -carefully managed by cool headed diplomats - cd be better but Remain can't see it
+  + missing FORMULA2
 
 # 43 Better for Concept #
 - FORMULA1 is better for CONCEPT than FORMULA2
 - concept = entity / system
 
 ## examples ##
-- **Brexit** would be **better for** **the young folks** than **staying in the EU**
+- **Brexit** would be better for **the young folks** than **staying in the EU**
 - fishermen would profit more from relaxed restrictions than worker right protection in the EU
 - higher CO2 costs would be more effective for climate protection than general speed limits
-- **Brexit** would be better for **the young folks** than **staying in the EU**
 
-## counter examples ##
-- I see IndyScot as a chance to improve for the majority (#8)
-- 40+ years ago this country was in a poor state, we're nowhere near as bad now. (not clear enough what exactly was/ is better)
--  Brexit might have a positive effect on the EU: discontents exit, resulting in a closer-knit and better-functioning EU-eurozone." (FORMULA2 not expressed)
+## counterexamples ##
+- I see IndyScot as a chance to improve for the majority
+  + #8
+- 40+ years ago this country was in a poor state, we're nowhere near as bad now.
+  + not clear enough what exactly was/ is better
+-  Brexit might have a positive effect on the EU: discontents exit, resulting in a closer-knit and better-functioning EU-eurozone."
+  + FORMULA2 not expressed
 - I feel ashamed of our Gov. Worse to have others feel sorry for us
 
 # 44 Good #
 - FORMULA is universally good (i.e. the scope is not explicitly limited to specific entities)
+
 ## examples ##
 - nation states are good
 - so the ideal will be Indy in EU with rUK still a member
 
-## counter-examples ##
+## counterexamples ##
 - Democracy is also often taken for granted
 
 # 45 Bad #
 - FORMULA is universally bad (i.e. the scope is not explicitly limited to specific entities)
-- It is enough for the FORMULA to be bad in only some aspects, regardless of whether it has positive characteristics as well
+- it is enough for the FORMULA to be bad in only some aspects, regardless of whether it has positive characteristics as well
 - expressions not relating directly to damage/danger but to changes in size/amount are not considered here, but understood as (negative) consequences
 
 ## examples ##
@@ -536,11 +565,14 @@ p10: belief
 - the system is flawed (= the system is bad, at least in some ways)
 - Leave's arguments just don't add up.
 
-## counter examples ##
-- the #UN - a unit of the globalist conspiracy (#21)
-- its illegal immigrants that are entering through the EU on false documents or nothing at all that worries me. (no explicit universal evaluation)
+## counterexamples ##
+- the #UN - a unit of the globalist conspiracy
+  + #21
+- its illegal immigrants that are entering through the EU on false documents or nothing at all that worries me.
+  + no explicit universal evaluation
 - I feel that if we Brexit, the rest of the world will view us as racist, bigoted and narrow-minded"
-- Bigoted bloody bunch (#21 because this is a negative evaluation of somebody's character rather than e.g. their overall 'suitability' as in the prime minister example)
+- Bigoted bloody bunch
+  + #21 because this is a negative evaluation of somebody's character rather than e.g. their overall 'suitability' as in the prime minister example
 
 ## problematic ##
 - so what exactly is wrong with an EU army
@@ -552,105 +584,56 @@ p10: belief
 - **as a son of immigrants** **I** am for **Brexit**
 - **the Left T.U. in me** says **No to leave** but **the #Motorbikes side of me** says **Yes vote to leave**
 
-# 48 Warning for some #
-- ENTITY1 says that FORMULA is/will be/ would be bad for CONCEPT
+# 48 Warning Some #
+- ENTITY says that FORMULA is/will be/ would be bad for CONCEPT
 
 ## examples ##
 - Correspondents: **Brexit** will batter **the comedy industry**, says **Stephen Grant**
 - **Brexit** would hit **poor** hardest, says **David Cameron**
 - **She** points out that **Brexit** endangers **pensions**
 
-# 49 warning of bad consequences for some #
-- ENTITY1 says that FORMULA has/ will have/ would have BAD CONSEQUENCES for CONCEPT
+# 49 Warning of Bad Consequences for Some #
+- ENTITY says that FORMULA has/ will have/ would have BAD CONSEQUENCES for CONCEPT
 
 ## examples ##
 - Hilary Benn has warned that Britain 's exit from the EU would make the country ' poorer ' and ' less influential'
 - Brexit could lead to downgrades for other EU countries -Fitch
 
-# 53 intention to do #
+# 53 Intention to Do #
 - ENTITY intends to do ACTION
-- Usually, statements expressing a future action without referencing intentions, plans etc. are interpreted as intention if subject = author (I will do X vs. She will do X)
+- usually, statements expressing a future action without referencing intentions, plans etc. are interpreted as intention if subject = author (I will do X vs. She will do X)
 
 ## examples ##
-- **1000 officials** travel to Strasbourg monthly **to vote** at a cost of €130m per annum
+- **1000 officials** travel to Strasbourg monthly to **vote** at a cost of €130m per annum
 - **French** to **brick up channel tunnel** in event of #BREXIT! (read as: are set / committed to brick up the tunnel)
 - **Stuart Rose** has probably switched sides to #Leave but agreed to stay quite to **save his blushes**
 - **I'm** **voting #Remain** with reservations, but pensioners stand to lose from #Brexit
 - Why does Brexit say "that's rubbish" and "**we'll** **negotiate to keep**" every time @LabourRemain point out something we'll lose
 - **Rich Audi drivers**, will **stay to avoid losing their 'richness'** (this is not just a future prediction because it contains a reason why they will stay)
-- $DIA You know **Warren Buffet** will drink his daily Cherry $KO and pull out his shopping bag **to buy buy buy** following the Brexit vote. $SPY (drink his daily Cherry $KO: prediction; pull out his shopping bag to buy: intention to do)
+- $DIA You know **Warren Buffet** will drink his daily Cherry $KO and pull out his shopping bag to **buy buy buy** following the Brexit vote. $SPY (drink his daily Cherry $KO: prediction; pull out his shopping bag to buy: intention to do)
 - "It's **this damn Brexit** tryin'a **lure us into an ambush**"
 - Why do you think **Trump** chose to **visit UK day after the referendum**? (chose to -> deliberate action)
 
-## counter-examples ##
-- Brexit vote set to fuel more referendums (prediction statement; no agency)
+## counterexamples ##
+- Brexit vote set to fuel more referendums 
+  + prediction statement; no agency
 - things will go up in price EVERYTHING WILL COST MORE!
 - But Trump is no mug &amp; he will trade with the UK despite Cameron
-- things will go up in price 
-- We're holding an English referendum next to decide whether we'll allow Scotland to stay (exception to the speaker + future construction -> intention rule: here, 'we' is understood as the government, i.e. the speaker presumably has no agency in what is happening, so the statement does not reflect their intention)
+- We're holding an English referendum next to decide whether we'll allow Scotland to stay 
+  + exception to the speaker + future construction -> intention rule: here, 'we' is understood as the government, i.e. the speaker presumably has no agency in what is happening, so the statement does not reflect their intention
 
-# 55 oppose #
-
+# 55 Opposition #
 - ENTITY opposes the truth of CONCEPT
-- Opposition is understood as the counter-part to desire: ENTITY wants the negation of CONCEPT to be true (NB: this is different from negated desire)
+- Opposition is understood as the counterpart to desire: ENTITY wants the negation of CONCEPT to be true (NB: this is different from negated desire)
 
 ## examples ##
 - **Junker** says no to **reform**. Germany say no tarrifs. #Brexit
 - @bbclaurak to be fair if **the Almighty** came out against **#Brexit**, Leavers would say his ubiquity prevents him taking a national view. #Remain
 - **Roxy** against **Brexit** watching the news nervously #DogsAgainstBrexit https://t.co/BrSp35RlnT
 
-## counter-examples ##
-- She doesn't want to come along (negated pattern 3)
-- They voted against Brexit (voting = action)
-- SCOTUS blocked the policy (banning = action)
-
-# 57 concept refinement #
-
-- ENTITY 0 is part of ENTITY 1, but this is not the claim of the overall statement
-- This pattern will typically apply to cases where the group membership is expressed via a modifying noun phrase
-- In contrast to pattern 24 there will usually be no verb phrase expressing membership; instead membership is considered background information on ENTITY 0
-
-## examples ##
-
-- ** the EU slave nations ** ** Germany and France **
-- ** star economist ** Thomas Pickety **
-- ** The Times' ** ** Jane Smith ** 
-- ** Billionaire Brexit supporter ** ** Max Doe ** 
-
-## counter-examples ##
-- Germany and France are slave nations (24)
-- Thomas Pickety is one of the top economists (24)
-
-# 58 Desirer #
-
-- group of entities desiring FORMULA to be true
-- Typical realisations: nouns tied to desire and relative phrases
-- No need for a specific entity
-
-## examples ##
-
-- Trump is a ** Brexit ** supporter (24+58)
-- ** Stay ** fans are right
-- People who want ** Brexit ** keep saying that
-
-## counter-examples ##
-
-- Trump supports Brexit (3)
-- I want to stay (3)
-- Cameron supporter (we can't extract any meaningful information from this because we would need too much background knowledge)
-
-# 59 Believer #
-
-- group of entities believing FORMULA to be true
-- Typical realisations: nouns tied to desire and relative phrases
-- No need for a specific entity
-
-## examples ##
-
-- anyone who truly believes ** that this is possible **
-
-## counter-examples ##
-- I believe ** this is possible ** (10)
+## counterexamples ##
+- She doesn't want to come along 
+  + negated #3
 
 # Categories #
 - entities vs entity groups


### PR DESCRIPTION
- unified inconsistent reference to patterns as "p5", "pattern 5"/"pattern #5" and "#5" to the latter
- started unifying inconsistent usage of bold and italics (WIP)
- corrected spelling of "counterexamples"
- minor punctuation edits
- unified usage of capitalisation in pattern names as titles, as well as the beginnings of bullet points
- reformatted many counterexamples to be more consistent
- deleted two duplicate counterexamples